### PR TITLE
Updating to use the partition key "personal" as required

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -59,3 +59,4 @@ ehthumbs.db
 
 # Folder config file
 Desktop.ini
+/.vs/config/applicationhost.config

--- a/src/Models/Item.cs
+++ b/src/Models/Item.cs
@@ -8,6 +8,9 @@
         [JsonProperty(PropertyName = "id")]
         public string Id { get; set; }
 
+        [JsonProperty(PropertyName = "category")]
+        public string Category = "personal";
+
         [JsonProperty(PropertyName = "name")]
         public string Name { get; set; }
 


### PR DESCRIPTION
When running the sample based on the documentation https://docs.microsoft.com/en-us/azure/cosmos-db/create-documentdb-dotnet it was failing due to missing request options for partitions. It works if I just hardcode the category to personal which is probably fine for a sample and update the 'get' call to allow crosspartition queries. 