### PR TITLE
Update DocumentDBRepository.cs

### DIFF
--- a/src/DocumentDBRepository.cs
+++ b/src/DocumentDBRepository.cs
@@ -23,7 +23,8 @@ namespace todo
             try
             {
                 Document document =
-                    await client.ReadDocumentAsync(UriFactory.CreateDocumentUri(DatabaseId, CollectionId, id));
+                    await client.ReadDocumentAsync(UriFactory.CreateDocumentUri(DatabaseId, CollectionId, id), 
+                    new RequestOptions { PartitionKey = new PartitionKey(category) });
                 return (T)(dynamic)document;
             }
             catch (DocumentClientException e)
@@ -68,7 +69,8 @@ namespace todo
 
         public static async Task DeleteItemAsync(string id, string category)
         {
-            await client.DeleteDocumentAsync(UriFactory.CreateDocumentUri(DatabaseId, CollectionId, id));
+            await client.DeleteDocumentAsync(UriFactory.CreateDocumentUri(DatabaseId, CollectionId, id), 
+                    new RequestOptions { PartitionKey = new PartitionKey(category) });
         }
 
         public static void Initialize()


### PR DESCRIPTION
Modified code to resolve runtime error, "PartitionKey value must be supplied for this operation." on Edit, Details, and Delete functionality. The error is now resolved and working fine as expected.